### PR TITLE
Adds Issue and PR Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Expected Behavior
+
+[Please give a detailed explanation of what you expected to happen. Include relevant links to the supporting Intacct documentation and code snippets as appropriate.]
+
+### Actual Behavior
+
+[Please give a detailed explanation of what actually happens. Include code snippets as appropriate.]
+
+### Steps to reproduce
+
+[Please give a walkthrough of the steps that got you to the problem. Include a link to a public gist/repo, an inline code sample, or a failing test!]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Contributor Self-Check:
+
+* [ ] My commits and messages [are solid](https://chris.beams.io/posts/git-commit/)
+* [ ] I have included tests that check success and failure
+* [ ] I have updated the README as appropriate
+
+### Which GitHub Issues does this PR address?
+
+[Copy/paste or search for your issue number by typing #]
+
+### What does this PR do?
+
+[Describe the problem and/or circumstances that lead to this PR. If this information is already laid out in the issue that you've linked, just copy/paste any necessary background info.]
+
+### How do I manually test this?
+
+[Detail is key! It might even be nice to set up some sample data for your tester.]
+
+### Additional Comments
+
+[This section is optional. Use it to give the maintainers a "heads ups!" about the code you've written.]
+
+### GIF for how this PR makes me feel
+
+![](GIF_URL)


### PR DESCRIPTION
### What issue does this address?
#11 

### What does this PR do?

Adds GitHub templates so that the issues and PRs of the future are more consistent and include the bare necessities

### How do I manually test this?

No need!

### Additional Comments

~I bumped the gem version one patch version here as there is no functional change. @toddsiegel Is that correct gem fu?~

### GIF for how this PR makes me feel

![](https://media.giphy.com/media/3o6MbeNr6v9XW7HNFS/giphy.gif)