### PR TITLE
[NEGO-3515] include api session logic

### DIFF
--- a/intacct_ruby.gemspec
+++ b/intacct_ruby.gemspec
@@ -1,37 +1,56 @@
-# coding: utf-8
+# -*- encoding: utf-8 -*-
+# stub: intacct_ruby 2.0.0 ruby lib
 
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'intacct_ruby/version'
+Gem::Specification.new do |s|
+  s.name = "intacct_ruby".freeze
+  s.version = "2.0.0"
 
-Gem::Specification.new do |spec|
-  spec.name                  = 'intacct_ruby'
-  spec.version               = IntacctRuby::VERSION
-  spec.authors               = ['Jeremy Zornow', 'Dan Powell']
-  spec.email                 = ['jeremy@zornow.com', 'dan.powell@privateprep.com']
-  spec.required_ruby_version = '>= 2.2.0'
-  spec.summary               = 'A Ruby wrapper for the Intacct API'
-  spec.description           = 'Allows for multi-function API calls, the ' \
-                               'addition of custom fields, and more. All in ' \
-                               'an easy-to-use package!'
-  spec.homepage              = 'https://github.com/privateprep/intacct-ruby'
-  spec.license               = 'MIT'
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Jeremy Zornow".freeze, "Dan Powell".freeze]
+  s.bindir = "exe".freeze
+  s.date = "2019-06-25"
+  s.description = "Allows for multi-function API calls, the addition of custom fields, and more. All in an easy-to-use package!".freeze
+  s.email = ["jeremy@zornow.com".freeze, "dan.powell@privateprep.com".freeze]
+  s.files = [".github/ISSUE_TEMPLATE.md".freeze, ".github/PULL_REQUEST_TEMPLATE.md".freeze, ".gitignore".freeze, ".rspec".freeze, ".travis.yml".freeze, "CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "Gemfile".freeze, "LICENSE.txt".freeze, "README.md".freeze, "Rakefile".freeze, "bin/console".freeze, "bin/setup".freeze, "intacct_ruby.gemspec".freeze, "lib/intacct_ruby.rb".freeze, "lib/intacct_ruby/api.rb".freeze, "lib/intacct_ruby/exceptions/empty_request_exception.rb".freeze, "lib/intacct_ruby/exceptions/function_failure_exception.rb".freeze, "lib/intacct_ruby/exceptions/insufficient_credentials_exception.rb".freeze, "lib/intacct_ruby/exceptions/unknown_function_type.rb".freeze, "lib/intacct_ruby/function.rb".freeze, "lib/intacct_ruby/request.rb".freeze, "lib/intacct_ruby/response.rb".freeze, "lib/intacct_ruby/version.rb".freeze]
+  s.homepage = "https://github.com/privateprep/intacct-ruby".freeze
+  s.licenses = ["MIT".freeze]
+  s.required_ruby_version = Gem::Requirement.new(">= 2.2.0".freeze)
+  s.rubygems_version = "2.7.9".freeze
+  s.summary = "A Ruby wrapper for the Intacct API".freeze
 
-  spec.files                 = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+  s.installed_by_version = "2.7.9" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_development_dependency(%q<bundler>.freeze, ["~> 1.13"])
+      s.add_development_dependency(%q<nokogiri>.freeze, ["~> 1.6", ">= 1.6.8"])
+      s.add_development_dependency(%q<mocha>.freeze, ["~> 0.13.3"])
+      s.add_development_dependency(%q<pry-byebug>.freeze, ["~> 3.4", ">= 3.4.2"])
+      s.add_development_dependency(%q<rake>.freeze, ["~> 10.0"])
+      s.add_development_dependency(%q<rspec>.freeze, ["~> 3.0"])
+      s.add_development_dependency(%q<travis>.freeze, ["~> 1.8", ">= 1.8.8"])
+      s.add_runtime_dependency(%q<builder>.freeze, ["~> 3.0", ">= 3.0.4"])
+    else
+      s.add_dependency(%q<bundler>.freeze, ["~> 1.13"])
+      s.add_dependency(%q<nokogiri>.freeze, ["~> 1.6", ">= 1.6.8"])
+      s.add_dependency(%q<mocha>.freeze, ["~> 0.13.3"])
+      s.add_dependency(%q<pry-byebug>.freeze, ["~> 3.4", ">= 3.4.2"])
+      s.add_dependency(%q<rake>.freeze, ["~> 10.0"])
+      s.add_dependency(%q<rspec>.freeze, ["~> 3.0"])
+      s.add_dependency(%q<travis>.freeze, ["~> 1.8", ">= 1.8.8"])
+      s.add_dependency(%q<builder>.freeze, ["~> 3.0", ">= 3.0.4"])
+    end
+  else
+    s.add_dependency(%q<bundler>.freeze, ["~> 1.13"])
+    s.add_dependency(%q<nokogiri>.freeze, ["~> 1.6", ">= 1.6.8"])
+    s.add_dependency(%q<mocha>.freeze, ["~> 0.13.3"])
+    s.add_dependency(%q<pry-byebug>.freeze, ["~> 3.4", ">= 3.4.2"])
+    s.add_dependency(%q<rake>.freeze, ["~> 10.0"])
+    s.add_dependency(%q<rspec>.freeze, ["~> 3.0"])
+    s.add_dependency(%q<travis>.freeze, ["~> 1.8", ">= 1.8.8"])
+    s.add_dependency(%q<builder>.freeze, ["~> 3.0", ">= 3.0.4"])
   end
-
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'nokogiri', '~> 1.6', '>= 1.6.8'
-  spec.add_development_dependency 'mocha', '~> 0.13.3'
-  spec.add_development_dependency 'pry-byebug', '~> 3.4', '>= 3.4.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'travis', '~> 1.8', '>= 1.8.8'
-
-  spec.add_runtime_dependency 'builder', '~> 3.0', '>= 3.0.4'
 end

--- a/lib/intacct_ruby/function.rb
+++ b/lib/intacct_ruby/function.rb
@@ -13,6 +13,7 @@ module IntacctRuby
       create
       update
       delete
+      getAPISession
     ).freeze
 
     CU_TYPES = %w(create update).freeze


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Ensure that you include the Jira ticket number in the title in the format [NEGO-12345] -->
<!--- All PRs **MUST** have either the data/change or data/no_change; if it is a data/change it must have a deploy_action label as well -->


Project: Sage Intacct Integration
Ticket: [NEGO-3515](https://negotiatus.atlassian.net/browse/NEGO-3515)

# Purpose
<!--- Why did you do this change? What problems are you attempting to address? -->
The `intacct-ruby` gem being used in the Sage Intacct integration does not use the `sessionid` element or `getAPISession` function when authenticating a client. Instead it is designed around using the login element.For our purposes, this needs to be updated.

## How can this be tested/tophatted?
<!--- Please describe how to set up the environment testing, such as migrations to run or what page it's on  -->

Contact @tmferretti for details

## Solution
<!--- Summarize the changes you made to the code and how it solves the initial problem -->
<!--- If you have significantly modified/created specs, include the business logic after the summary; they can be generated with the below command -->
<!-- docker-compose -f docker-compose.test.yml run test rspec path/to/spec1.rb:line# path/to/spec2.rb:line# -fd -->

## Stakeholders
<!--- List of people who need to approve these changes, including non-engineering -->
<!--- Everyone in this list must either have a comment, approval, or noted as approving if they are not on Github -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My changes follow our styles and conventions for this project.
- [x] I have updated/checked that our documentation is consistent with my changes.
- [ ] I have updated/checked that tests cover my changes.
- [ ] All new and existing tests passed.
