### PR TITLE
Reconfigure dependencies, get CI passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: ruby
 rvm:
 - 2.2.9
 - 2.3.6
-- 2.4.3
-- 2.5.0
+- 2.4.9
+- 2.5.7
+- 2.6.5
+- 2.7.0
 script:
 - bundle exec rspec
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Get CI Passing ([@danielpowell4](https://github.com/danielpowell4) in [#22](https://github.com/privateprep/intacct-ruby/pull/33))
+
 # 2.0.0 (May 18, 2018)
 
 * Use keyword-args ([@bezoar17](https://github.com/bezoar17) in [#20](https://github.com/privateprep/intacct-ruby/pull/20))

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,12 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in intacct_ruby.gemspec
 gemspec
+
+group :development do
+  gem 'nokogiri', '~> 1.6', '>= 1.6.8'
+  gem 'mocha', '~> 0.13.3'
+  gem 'pry-byebug', '~> 3.4', '>= 3.4.2'
+  gem 'rake', '~> 10.0'
+  gem 'rspec', '~> 3.0'
+  gem 'travis', '~> 1.8', '>= 1.8.8'
+end

--- a/intacct_ruby.gemspec
+++ b/intacct_ruby.gemspec
@@ -25,13 +25,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.13'
-  spec.add_development_dependency 'nokogiri', '~> 1.6', '>= 1.6.8'
-  spec.add_development_dependency 'mocha', '~> 0.13.3'
-  spec.add_development_dependency 'pry-byebug', '~> 3.4', '>= 3.4.2'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'travis', '~> 1.8', '>= 1.8.8'
-
   spec.add_runtime_dependency 'builder', '~> 3.0', '>= 3.0.4'
 end


### PR DESCRIPTION
Think this is obvious. The 'win' here was removing the
version of bundler from the gemspec and letting whatever
travis picked 'win'

Also added a few new ruby versions to be safe
