### PR TITLE
Fix error on Request class for compatibility with ruby 3

### DIFF
--- a/lib/intacct_ruby/request.rb
+++ b/lib/intacct_ruby/request.rb
@@ -65,11 +65,11 @@ module IntacctRuby
 
     private
 
-    def method_missing(method_name, *arguments, &block)
+    def method_missing(method_name, **opts, &block)
       super unless Function::ALLOWED_TYPES.include? method_name.to_s
 
       # object_type must be the first argument in arguments
-      @functions << Function.new(method_name, arguments.shift, *arguments)
+      @functions << Function.new(method_name, object_type: opts.delete(:object_type), **opts)
     end
 
     def respond_to_missing?(method_name, include_private = false)


### PR DESCRIPTION
### What does this PR do?

Ruby 3.0 has changed how positional and keyword arguments are handled, as explained here:

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This is causing `intacct_ruby` to fail:

![image](https://user-images.githubusercontent.com/32207177/234106714-65d67751-3ab1-4aec-9ca4-f4a5916aa13a.png)

### How do I manually test this?

- We've been using the gem with this patch and everything works as expected.
- We've also run current tests without error in Ruby versions 3.1.3, 2.7.7 and 2.6.9.
